### PR TITLE
testing if we can dump tags from graphql so we don't have to clone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@octokit/core": "^6.0.1",
+        "@octokit/plugin-paginate-graphql": "^5.1.0",
         "@octokit/plugin-paginate-rest": "^9.2.0",
         "@octokit/plugin-throttling": "^9.0.2",
         "shelljs": "^0.8.5",
@@ -73,6 +74,17 @@
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
       "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+    },
+    "node_modules/@octokit/plugin-paginate-graphql": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-5.1.0.tgz",
+      "integrity": "sha512-0qSLhU9pc1OZ3Qwhn9QPS0O+JN6a8Xr0SHbL2WYyTnwC0exKI3fwNrSqI6z8jAqni04wD9snU8eX3oJYP/3A8g==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "dependencies": {
     "@octokit/core": "^6.0.1",
+    "@octokit/plugin-paginate-graphql": "^5.1.0",
     "@octokit/plugin-paginate-rest": "^9.2.0",
     "@octokit/plugin-throttling": "^9.0.2",
     "shelljs": "^0.8.5",

--- a/scan-repos.js
+++ b/scan-repos.js
@@ -196,7 +196,7 @@ async function main() {
                     const tag_query = `
                         query paginate($cursor: String) {
                             repository(owner: "${argv.org}", name: "${repository.name}") {
-                                refs(refPrefix: "tags/", first: 10, after: $cursor) {
+                                refs(refPrefix: "refs/tags/", first: 10, after: $cursor) {
                                     nodes {
                                         name
                                         prefix

--- a/scan-repos.js
+++ b/scan-repos.js
@@ -196,7 +196,7 @@ async function main() {
                     const tag_query = `
                         query paginate($cursor: String) {
                             repository(owner: "${argv.org}", name: "${repository.name}") {
-                                refs(first: 10, after: $cursor) {
+                                refs(refPrefix: "tags/", first: 10, after: $cursor) {
                                     nodes {
                                         name
                                         prefix

--- a/scan-repos.js
+++ b/scan-repos.js
@@ -1,12 +1,12 @@
 import { throttling } from "@octokit/plugin-throttling";
 import { paginateRest } from "@octokit/plugin-paginate-rest";
-import { paginateGraphql } from "@octokit/plugin-paginate-graphql";
+import { paginateGraphQL } from "@octokit/plugin-paginate-graphql";
 import { Octokit } from "@octokit/core";
 import shell from 'shelljs';
 import yargs from 'yargs';
 import util from 'util';
 
-const MyOctokit = Octokit.plugin(throttling, paginateRest, paginateGraphql);
+const MyOctokit = Octokit.plugin(throttling, paginateRest, paginateGraphQL);
 
 const paginate_graphql = async (logger, client, query, options = {}) => {
     /*


### PR DESCRIPTION
This pull request primarily introduces the use of the `@octokit/plugin-paginate-graphql` package to the codebase, which allows for the pagination of GraphQL queries. This change is reflected in the `package.json` and `scan-repos.js` files. The `scan-repos.js` file has also been updated to include a new function `paginate_graphql` and additional code in the `main` function to handle GraphQL queries.

Closes #16 